### PR TITLE
Early return when decoded payload is too short

### DIFF
--- a/fernet.go
+++ b/fernet.go
@@ -71,6 +71,9 @@ func verify(msg, tok []byte, ttl time.Duration, now time.Time, k *Key) []byte {
 		return nil
 	}
 	n := len(tok) - sha256.Size
+	if n <= 0 {
+		return nil
+	}
 	var hmac [sha256.Size]byte
 	genhmac(hmac[:0], tok[:n], k.signBytes())
 	if subtle.ConstantTimeCompare(tok[n:], hmac[:]) != 1 {

--- a/invalid.json
+++ b/invalid.json
@@ -54,5 +54,12 @@
     "now": "1985-10-26T01:20:01-07:00",
     "ttl_sec": 60,
     "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "very short payload size",
+    "token": "gAAAAABdnQ1TUKh2OE_ggbyCIxfg",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 0,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
   }
 ]


### PR DESCRIPTION
When decoded payload is shorter than sha256.Size, verify function could
panic because it tries to negatively slice the payload. Return early to
avoid panic and also add a test case for it.